### PR TITLE
Reducing MOAS consumer memory consumption

### DIFF
--- a/lib/consumers/bvc_moas.c
+++ b/lib/consumers/bvc_moas.c
@@ -770,10 +770,20 @@ void bvc_moas_destroy(bvc_t *consumer)
   if (state != NULL) {
 
     if (state->current_moases != NULL) {
-      khiter_t p;
+      moasinfo_map_t *per_pfx_moases;
+      moas_signature_t *ms;
+      khiter_t p,m;
       for (p = kh_begin(state->current_moases);
            p != kh_end(state->current_moases); p++) {
         if (kh_exist(state->current_moases, p)) {
+          /* free dynamic origins array for each moas */
+          per_pfx_moases = kh_val(state->current_moases, p);
+          for (m = kh_begin(per_pfx_moases); m != kh_end(per_pfx_moases); m++) {
+            if (kh_exist(per_pfx_moases, m)) {
+              ms = &kh_key(per_pfx_moases, m);
+              free(ms->origins_dyn);
+            }
+          }
           kh_destroy(moasinfo_map, kh_val(state->current_moases, p));
         }
       }


### PR DESCRIPTION
This PR contains code changes to `bvc_moas.c` targeted to reduce the memory consumption of the MOAS consumer.

The main change is that I changed the `moas_signature` struct to use a combination of small static allocated array and a large dynamically allocated array, instead of always using max-size statically allocated array.

For the most of the MOAS events, the number of origins within is less than 4 ASes (85 percentile at the time of PR). Therefore we use 4 as the size of the static array. If there are more than 4 origins in the event, we will allocate an array of size 128 to accommodate the extreme cases.

Room for further improvement:
- instead of always allocate 128 origins when greater than 4, we can consider allocate a step at a time. however, this complicates the complexity of the code considerably.