### PR TITLE
Replace sparse peer array with much smaller khash

### DIFF
--- a/lib/bgpview.c
+++ b/lib/bgpview.c
@@ -351,8 +351,8 @@ static int peerid_pfxinfo_insert(bgpview_iter_t *iter, bgpstream_pfx_t *prefix,
 
   peerinfo->as_path_id = path_id;
 
-  if (khret > 0) {
-    // did not already exist
+  if (peerinfo->state == BGPVIEW_FIELD_INVALID) {
+    // did not already exist or was invalid
     peerinfo->state = BGPVIEW_FIELD_INACTIVE;
 
     /** peerinfo->user remains untouched */


### PR DESCRIPTION
In bwv_peerid_pfxinfo, peers were stored in a sparse array bounded by
the max peerid in the array, which wasted a lot of space.  Furthermore,
the amount of waste depended on the order in which peerids were
assigned.  Replacing that with a much denser khash saves a lot of
memory, given that pfxpeer info can number in the hundereds of millions,
and is not dependant on input order.

In one measurement, the old array had a density was around .222 to .234,
and the new khash has a density of .540.  The khash requires 2 extra
bytes per record for the peerid, but that's more than offset by the
increased density.