### PR TITLE
pfx-origins: dynamically grow the origins array rather than relying on 1 large static allocation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "common"]
 	path = common
-	url = git://github.com/caida/cc-common.git
+	url = https://github.com/caida/cc-common.git

--- a/lib/consumers/bvc_pfxorigins.c
+++ b/lib/consumers/bvc_pfxorigins.c
@@ -233,7 +233,7 @@ static int process_origin_state(bvc_t *consumer, uint32_t current_view_ts)
         for (i = 0; i < os->current.num_asns; i++) {
           bgpstream_as_path_seg_destroy(os->current.origin_asns[i]);
         }
-	free(os->current.origin_asns);
+	    free(os->current.origin_asns);
       } else {
 
         /* if the prefix disappeared, we remove it from
@@ -569,9 +569,9 @@ int bvc_pfxorigins_process_view(bvc_t *consumer, bgpview_t *view)
             os->previous.array_size = ARRAY_SIZE_INCR;
             os->current.num_asns = 0;
             os->current.array_size = ARRAY_SIZE_INCR;
-	    os->current.origin_asns = calloc(ARRAY_SIZE_INCR,
+	        os->current.origin_asns = calloc(ARRAY_SIZE_INCR,
 			   sizeof(bgpstream_as_path_seg_t *));
-	    os->previous.origin_asns = calloc(ARRAY_SIZE_INCR,
+	        os->previous.origin_asns = calloc(ARRAY_SIZE_INCR,
 			   sizeof(bgpstream_as_path_seg_t *));
           }
           /* get os pointer */
@@ -590,19 +590,23 @@ int bvc_pfxorigins_process_view(bvc_t *consumer, bgpview_t *view)
         }
 
         if (!found) {
-	  if (os->current.num_asns >= os->current.array_size - 1) {
-	      char pfxstr[1024];
-              os->current.origin_asns = realloc(os->current.origin_asns,
+	      if (os->current.num_asns >= os->current.array_size - 1) {
+	        char pfxstr[1024];
+            os->current.origin_asns = realloc(os->current.origin_asns,
 			      (os->current.array_size + ARRAY_SIZE_INCR) *
 			       sizeof(bgpstream_as_path_seg_t *));
+            if (os->current.origin_asns == NULL) {
+              fprintf(stderr, "Could not allocate memory for origins array\n");
+              return -1;
+            }
 
-	      os->current.array_size += ARRAY_SIZE_INCR;
-	      bgpstream_pfx_snprintf(pfxstr, 1024, pfx);
-	      fprintf(stderr, "Resizing %s origin ASN array to %d\n",
+	        os->current.array_size += ARRAY_SIZE_INCR;
+	        bgpstream_pfx_snprintf(pfxstr, 1024, pfx);
+	        fprintf(stderr, "DEBUG: Resizing %s origin ASN array to %d\n",
 			      pfxstr, os->current.array_size);
-	  }
+	      }
           os->current.origin_asns[os->current.num_asns] =
-            bgpstream_as_path_seg_dup(origin_seg);
+              bgpstream_as_path_seg_dup(origin_seg);
           if (os->current.origin_asns[os->current.num_asns] == NULL) {
             fprintf(stderr, "Could not allocate memory for AS segment\n");
             return -1;

--- a/lib/consumers/bvc_pfxorigins.c
+++ b/lib/consumers/bvc_pfxorigins.c
@@ -252,18 +252,18 @@ static int process_origin_state(bvc_t *consumer, uint32_t current_view_ts)
           }
         }
 
-        for (i = os->current.num_asns; i < os->previous.num_asns; i++) {
+        for (i = 0; i < os->previous.num_asns; i++) {
           if (os->previous.origin_asns[i] != NULL) {
             bgpstream_as_path_seg_destroy(os->previous.origin_asns[i]);
             os->previous.origin_asns[i] = NULL;
           }
         }
-	free(os->previous.origin_asns);
-	os->previous.origin_asns = os->current.origin_asns;
+	    free(os->previous.origin_asns);
+	    os->previous.origin_asns = os->current.origin_asns;
 
         /* update previous counter */
         os->previous.num_asns = os->current.num_asns;
-	os->previous.array_size = os->current.array_size;
+	    os->previous.array_size = os->current.array_size;
 
       }
       // reset current (no destroy is called, objects are in previous now)

--- a/lib/consumers/bvc_pfxorigins.c
+++ b/lib/consumers/bvc_pfxorigins.c
@@ -55,7 +55,7 @@
 /** Default maximum number of unique origins */
 #define MAX_ORIGIN_AS_CNT 65535
 
-#define ARRAY_SIZE_INCR 64
+#define ARRAY_SIZE_INCR 32
 
 /** MAX LEN of AS PATH SEGMENT STR  */
 #define MAX_ASPATH_SEGMENT_STR 255 * 16


### PR DESCRIPTION
Previously:
 - each prefix is allocated an array with 64 entries to store observed origin ASNs

Problems:
 - a prefix with more than 64 origins would cause the consumer to crash with an assertion failure
 - almost all prefixes have far less than 64 origins, so the memory allocated for each array is effectively wasted

Solution in this PR:
 - initial array allocation is now 32 entries
 - if number of origins is going to exceed the array size, dynamically extend the array by another 32 entries

Result:
 - consumer no longer crashes when a prefix has a large number of origins (e.g. 192.58.128.0/24 )
 - overall memory footprint of the pfx-origins consumer should be reduced

Other changes:
 - individual copying of origin array entries from `current` to `previous` is no longer required (since we can now just copy the pointer to the whole array across), so performance may also be improved slightly.
 - change `.gitmodules` to fetch submodules using HTTPS instead of `git://`, which has an annoying tendency to time out especially in containerized environments.